### PR TITLE
Add validity check for SAML certs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,36 @@
 # nagios-check-saml-entity
-Nagios plugin to check validity of the TLS certificate on the AssertionConsumerLocation URL of a SAML entity, through a metadata query
+Nagios plugin to check various properties of a SAML entity, either from an MDQ,
+a regular URL, or a local file path.
+
+Currently implemented checks:
+
+- The validity of the TLS certificate of the Assertion Consumer URL
+- The validity of the SAML signing/encryption certificate(s)
+
+
+
+
+# Usage
+
+```
+usage: nagios-check-saml-entity.py [-h] (--location LOCATION | --mdq MDQ)
+                                   --entity ENTITY
+                                   [--acs-url-tls-cert-days ACS_URL_TLS_CERT_DAYS]
+                                   [--saml-cert-days SAML_CERT_DAYS]
+
+Check various properties of a SAML entity
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --location LOCATION   The location of the metadata file. Can be a path or a
+                        URL. Mutually exclusive with the --mdq option
+  --mdq MDQ             The base URL of an MDQ responder. Mutually exclusive
+                        with the --location option
+  --entity ENTITY       the entityID to check
+  --acs-url-tls-cert-days ACS_URL_TLS_CERT_DAYS
+                        Minimum number of days the TLS certificate of the SAML
+                        Assertion Consumer URL has to be valid
+  --saml-cert-days SAML_CERT_DAYS
+                        Minimum number of days the SAML certificate(s) have to
+                        be valid
+```

--- a/README.md
+++ b/README.md
@@ -7,9 +7,6 @@ Currently implemented checks:
 - The validity of the TLS certificate of the Assertion Consumer URL
 - The validity of the SAML signing/encryption certificate(s)
 
-
-
-
 # Usage
 
 ```
@@ -33,4 +30,24 @@ optional arguments:
   --saml-cert-days SAML_CERT_DAYS
                         Minimum number of days the SAML certificate(s) have to
                         be valid
+```
+
+# Examples
+
+```sh
+# Check the TLS certificate of an entity's Assertion Consumer Service URL, using an MDQ
+./nagios-check-saml-entity.py \
+  --mdq https://proxy.eduteams.org \
+  --entity https://proxy.eduteams.org/metadata/backend.xml \
+  --acs-url-tls-cert-days 21
+OK: TLS certificate for 'proxy.eduteams.org' is valid until Jul 15 23:59:59 2022 GMT (expires in 532 days)
+```
+
+```sh
+# Check the expiration of any of the SAML signing/encryption certificates
+./nagios-check-saml-entity.py \
+  --entity https://terena.org/sp \
+  --mdq https://mdx.eduteams.org \
+  --saml-cert-days 12
+CRITICAL: A SAML certificate expired on Mon Jan 11 15:26:38 2021 (19 days ago)
 ```

--- a/nagios-check-saml-entity.py
+++ b/nagios-check-saml-entity.py
@@ -27,7 +27,7 @@ try:
             description='Check various properties of a SAML entity'
             )
 
-   
+
     source = parser.add_mutually_exclusive_group(required=True)
     source.add_argument('--location',
             help='The location of the metadata file. Can be a path or a URL. ' +

--- a/nagios-check-saml-entity.py
+++ b/nagios-check-saml-entity.py
@@ -11,7 +11,8 @@ import ssl
 import socket
 from pprint import pprint
 from datetime import datetime
-
+from cryptography import x509
+import base64
 
 # Debug
 # import logging
@@ -25,20 +26,31 @@ try:
     parser = argparse.ArgumentParser(
             description='Check various properties of a SAML entity'
             )
+
     parser.add_argument('--entity',
             help='the entityID to check',
             required=True
             )
    
-    # https://github.com/iay/md-query/blob/master/draft-young-md-query.txt#L362
-    parser.add_argument('--mdq',
-            help='The base URL of the MDQ responder',
-            required=True
+    group1 = parser.add_mutually_exclusive_group()
+    group1.add_argument('--location',
+            help='The location of the metadata file. Can be a path or a URL. ' +
+                'Mutually exclusive with the --mdq option',
             )
-    parser.add_argument('--warning',
-            help='Minimum number of days a certificate has to be valid to issue a WARNING',
+    # https://github.com/iay/md-query/blob/master/draft-young-md-query.txt#L362
+    group1.add_argument('--mdq',
+            help='The base URL of the MDQ responder. Mutually exclusive with ' +
+                'the --location option',
+            )
+
+    parser.add_argument('--tls_cert_days',
+            help='Minimum number of days the TLS certificate of the SAML ' +
+                'Assertion Consumer URL has to be valid',
             type=int,
-            default=21
+            )
+    parser.add_argument('--saml_cert_days',
+            help='Minimum number of days a SAML certificate has to be valid',
+            type=int,
             )
 
     
@@ -50,39 +62,79 @@ try:
     warn_msg = []
     crit_msg = []
 
+    # pprint(args)
 
-    url = "{base}/entities/{endpoint}".format(
-        base=args.mdq,
-        endpoint=MetaDataMDX.sha1_entity_transform(args.entity),
-    )
     mds = MetadataStore(attrc=None, config=Config())
-    mds.load("remote", url=url)
-    res = mds.assertion_consumer_service(entity_id=args.entity)
-    acs_url = next(iter(res), {}).get("location")
 
-    hostname = urlparse(acs_url).hostname
-    context = ssl.create_default_context()
-    with socket.create_connection((hostname, 443)) as sock:
-        with context.wrap_socket(sock, server_hostname = hostname) as tls_sock:
-            cert = tls_sock.getpeercert()
-            # pprint(cert)
-            if 'notAfter' in cert:
-                expire_date = datetime.strptime(cert['notAfter'],
-                        "%b %d %H:%M:%S %Y %Z")
-                expire_in = expire_date - datetime.now()
 
-                if expire_in.days < 0:
-                    crit_msg.append("X.509 certificate '" + hostname +
-                            "' expired on " + cert['notAfter'] +
-                            " (" + str(abs(expire_in.days)) + " days ago)")
-                elif expire_in.days < args.warning:
-                    warn_msg.append("X.509 certificate '" + hostname +
-                            "' is valid until " + cert['notAfter'] +
-                            " (expires in " + str(expire_in.days) + " days)")
-                else:
-                    ok_msg.append("X.509 certificate '" + hostname +
-                            "' is valid until " + cert['notAfter'] +
-                            " (expires in " + str(expire_in.days) + " days)")
+    if args.mdq is not None:
+        url = "{base}/entities/{endpoint}".format(
+            base=args.mdq,
+            endpoint=MetaDataMDX.sha1_entity_transform(args.entity),
+        )
+    if urlparse(args.location).scheme in ['http', 'https']:
+        url=args.location
+        mds.load("remote", url=url)
+    else:
+        mds.load("local", args.location)
+
+
+    # Expiration check on the TLS certificate of the SAML ACS URL
+    if args.tls_cert_days is not None:
+        acs_res = mds.assertion_consumer_service(entity_id=args.entity)
+        acs_url = next(iter(acs_res), {}).get("location")
+        hostname = urlparse(acs_url).hostname
+        if urlparse(acs_url).scheme == 'https':
+            context = ssl.create_default_context()
+            with socket.create_connection((hostname, 443)) as sock:
+                with context.wrap_socket(sock, server_hostname = hostname) as tls_sock:
+                    cert = tls_sock.getpeercert()
+                    # pprint(cert)
+                    if 'notAfter' in cert:
+                        expire_date = datetime.strptime(cert['notAfter'],
+                                "%b %d %H:%M:%S %Y %Z")
+                        expire_in = expire_date - datetime.now()
+
+                        if expire_in.days < 0:
+                            crit_msg.append("TLS certificate for '" + hostname +
+                                    "' expired on " + cert['notAfter'] +
+                                    " (" + str(abs(expire_in.days)) + " days ago)")
+                        elif expire_in.days < args.tls_cert_days:
+                            warn_msg.append("TLS certificate for '" + hostname +
+                                    "' is valid until " + cert['notAfter'] +
+                                    " (expires in " + str(expire_in.days) + " days)")
+                        else:
+                            ok_msg.append("TLS certificate for '" + hostname +
+                                    "' is valid until " + cert['notAfter'] +
+                                    " (expires in " + str(expire_in.days) + " days)")
+        else:
+            warn_msg.append("Non-HTTPS Assertion Consumer Service URL: " + acs_url)
+
+    if args.saml_cert_days is not None:
+        certs = list(set(
+            mds.certs(entity_id=args.entity, descriptor='any', use='encryption') +
+            mds.certs(entity_id=args.entity, descriptor='any', use='signing')))
+        if len(certs) > 0:
+            for i in certs:
+                cert = x509.load_der_x509_certificate(base64.b64decode(i))
+                if cert.not_valid_after:
+                    expire_in = cert.not_valid_after - datetime.now()
+
+                    if expire_in.days < 0:
+                        crit_msg.append("A SAML certificate expired on " +
+                                cert.not_valid_after.ctime() +
+                                " (" + str(abs(expire_in.days)) + " days ago)")
+                    elif expire_in.days < args.saml_cert_days:
+                        warn_msg.append("A SAML certificate is valid until " +
+                                cert.not_valid_after.ctime() +
+                                " (expires in " + str(expire_in.days) + " days)")
+                    else:
+                        ok_msg.append("A SAML certificate is valid until " +
+                                cert.not_valid_after.ctime() +
+                                " (expires in " + str(expire_in.days) + " days)")
+        else:
+            ok_msg.append("No SAML certificates found in metatada for entity " + args.entity)
+
 
 except Exception as e:
     # pprint(e)

--- a/nagios-check-saml-entity.py
+++ b/nagios-check-saml-entity.py
@@ -60,7 +60,7 @@ try:
 
     args = parser.parse_args()
 
-    pprint(args)
+    # pprint(args)
 
     std_args = ['entity', 'mdq', 'location']
     required_args = { key: val for (key, val) in vars(args).items() if key not in std_args }

--- a/nagios-check-saml-entity.py
+++ b/nagios-check-saml-entity.py
@@ -12,6 +12,7 @@ import socket
 from pprint import pprint
 from datetime import datetime
 from cryptography import x509
+from cryptography.hazmat.backends import default_backend
 import base64
 
 # Debug
@@ -127,7 +128,7 @@ try:
             mds.certs(entity_id=args.entity, descriptor='any', use='signing')))
         if len(certs) > 0:
             for i in certs:
-                cert = x509.load_der_x509_certificate(base64.b64decode(i))
+                cert = x509.load_der_x509_certificate(base64.b64decode(i), default_backend())
                 if cert.not_valid_after:
                     expire_in = cert.not_valid_after - datetime.now()
 

--- a/nagios-check-saml-entity.py
+++ b/nagios-check-saml-entity.py
@@ -27,20 +27,21 @@ try:
             description='Check various properties of a SAML entity'
             )
 
-    parser.add_argument('--entity',
-            help='the entityID to check',
-            required=True
-            )
    
-    group1 = parser.add_mutually_exclusive_group()
-    group1.add_argument('--location',
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument('--location',
             help='The location of the metadata file. Can be a path or a URL. ' +
                 'Mutually exclusive with the --mdq option',
             )
     # https://github.com/iay/md-query/blob/master/draft-young-md-query.txt#L362
-    group1.add_argument('--mdq',
-            help='The base URL of the MDQ responder. Mutually exclusive with ' +
+    source.add_argument('--mdq',
+            help='The base URL of an MDQ responder. Mutually exclusive with ' +
                 'the --location option',
+            )
+
+    parser.add_argument('--entity',
+            help='the entityID to check',
+            required=True
             )
 
     parser.add_argument('--tls_cert_days',
@@ -49,7 +50,7 @@ try:
             type=int,
             )
     parser.add_argument('--saml_cert_days',
-            help='Minimum number of days a SAML certificate has to be valid',
+            help='Minimum number of days the SAML certificate(s) have to be valid',
             type=int,
             )
 


### PR DESCRIPTION
- Added new `--location` argument to fetch metadata from. This can be a local file path or a URL. This argument is mutually exclusive with `--mdq`.
- Added support for checking the expiration date of the SAML certificates (`--saml-cert-days`)
- Now that there is more than one check:
  - Renamed `warning` argument to `--acs-url-tls-cert-days`
  - Require at least one check to be run